### PR TITLE
Enhance service graph harvesting and reporting

### DIFF
--- a/aci_docgen/harvesters/service_graphs.py
+++ b/aci_docgen/harvesters/service_graphs.py
@@ -1,21 +1,61 @@
+from collections import defaultdict
+
 from ..utils.normalize import simple_attr
 
 def harvest_service_graphs_for_tenant(api, tenant):
     subtree = api.mo_subtree(tenant['dn'])
-    graphs = []
     dn_to_graph = {}
+    node_lookup = {}
+    graph_name_to_dn = {}
+    graph_bindings = defaultdict(list)
     # abstract graphs
     for item in subtree.get('imdata', []):
         if 'vnsAbsGraph' in item:
             a = simple_attr(item, 'vnsAbsGraph')
-            dn_to_graph[a.get('dn')] = {'name': a.get('name'), 'nodes': [], 'redirect_policies': []}
+            dn = a.get('dn')
+            if not dn:
+                continue
+            graph = {
+                'name': a.get('name'),
+                'dn': dn,
+                'nodes': [],
+                'connections': [],
+                'redirect_policies': [],
+                'bound_contract_subjects': [],
+            }
+            dn_to_graph[dn] = graph
+            if a.get('name'):
+                graph_name_to_dn[a.get('name')] = dn
     # nodes
     for item in subtree.get('imdata', []):
         if 'vnsAbsNode' in item:
             a = simple_attr(item, 'vnsAbsNode')
             parent = a.get('dn', '').split('/AbsNode-')[0]
             if parent in dn_to_graph:
-                dn_to_graph[parent]['nodes'].append({'name': a.get('name'), 'funcType': a.get('funcType')})
+                node = {
+                    'name': a.get('name'),
+                    'funcType': a.get('funcType'),
+                    'dn': a.get('dn'),
+                    'connectors': [],
+                }
+                dn_to_graph[parent]['nodes'].append(node)
+                if node['dn']:
+                    node_lookup[node['dn']] = node
+    # node connectors
+    for item in subtree.get('imdata', []):
+        if 'vnsAbsFuncConn' in item:
+            a = simple_attr(item, 'vnsAbsFuncConn')
+            node_dn = a.get('dn', '').split('/AbsFuncConn-')[0]
+            node = node_lookup.get(node_dn)
+            if not node:
+                continue
+            connector_attrs = _clean_attributes(a)
+            connector = {
+                'name': a.get('name'),
+                'attributes': connector_attrs,
+                'summary': _build_connector_summary(a),
+            }
+            node['connectors'].append(connector)
     # redirect policies (if any)
     for item in subtree.get('imdata', []):
         if 'vnsRedirectPol' in item:
@@ -24,5 +64,143 @@ def harvest_service_graphs_for_tenant(api, tenant):
             parent = a.get('dn', '').split('/redirectPol-')[0]
             for dn in dn_to_graph:
                 if parent.startswith(dn):
-                    dn_to_graph[dn]['redirect_policies'].append({'name': a.get('name')})
-    return list(dn_to_graph.values())
+                    name = a.get('name')
+                    if name and name not in dn_to_graph[dn]['redirect_policies']:
+                        dn_to_graph[dn]['redirect_policies'].append(name)
+    # graph connections
+    for item in subtree.get('imdata', []):
+        if 'vnsAbsConnection' in item:
+            a = simple_attr(item, 'vnsAbsConnection')
+            parent = a.get('dn', '').split('/AbsConnection-')[0]
+            if parent in dn_to_graph:
+                connection_attrs = _clean_attributes(a)
+                connection = {
+                    'name': a.get('name'),
+                    'attributes': connection_attrs,
+                    'summary': _build_connection_summary(a),
+                }
+                dn_to_graph[parent]['connections'].append(connection)
+    # contract bindings (graph references)
+    for item in subtree.get('imdata', []):
+        if 'vzRsSubjGraphAtt' in item:
+            _record_binding(
+                item,
+                'vzRsSubjGraphAtt',
+                dn_to_graph,
+                graph_name_to_dn,
+                graph_bindings,
+            )
+        elif 'vzRsGraphAtt' in item:
+            _record_binding(
+                item,
+                'vzRsGraphAtt',
+                dn_to_graph,
+                graph_name_to_dn,
+                graph_bindings,
+            )
+    # finalise graphs
+    graphs = []
+    for dn, graph in dn_to_graph.items():
+        graph['bound_contract_subjects'] = graph_bindings.get(dn, [])
+        # strip helper fields not needed by templates
+        cleaned_nodes = []
+        for node in graph['nodes']:
+            cleaned_connectors = [
+                {k: v for k, v in connector.items() if k != 'attributes' or v}
+                for connector in node.get('connectors', [])
+            ]
+            cleaned_node = {k: v for k, v in node.items() if k != 'dn'}
+            cleaned_node['connectors'] = cleaned_connectors
+            cleaned_nodes.append(cleaned_node)
+        graph['nodes'] = cleaned_nodes
+        graph['connections'] = [
+            {k: v for k, v in connection.items() if k != 'attributes' or v}
+            for connection in graph['connections']
+        ]
+        graph.pop('dn', None)
+        graphs.append(graph)
+    return graphs
+
+
+def _clean_attributes(attrs):
+    """Remove noisy keys from an attribute dictionary."""
+
+    ignored = {'childAction', 'dn', 'lcOwn', 'modTs', 'rn', 'status', 'uid'}
+    cleaned = {}
+    for key, value in attrs.items():
+        if key in ignored:
+            continue
+        if value in (None, '', 'unspecified'):
+            continue
+        cleaned[key] = value
+    return cleaned
+
+
+def _build_connector_summary(attrs):
+    name = attrs.get('name') or 'connector'
+    parts = []
+    if attrs.get('connType'):
+        parts.append(f"connType: {attrs['connType']}")
+    if attrs.get('type'):
+        parts.append(f"type: {attrs['type']}")
+    if attrs.get('order'):
+        parts.append(f"order: {attrs['order']}")
+    if attrs.get('adjType'):
+        parts.append(f"adjType: {attrs['adjType']}")
+    if attrs.get('directConnectPort'):
+        parts.append(f"directPort: {attrs['directConnectPort']}")
+    return f"{name} ({', '.join(parts)})" if parts else name
+
+
+def _build_connection_summary(attrs):
+    name = attrs.get('name') or 'connection'
+    parts = []
+    if attrs.get('connDir'):
+        parts.append(f"dir: {attrs['connDir']}")
+    if attrs.get('connType'):
+        parts.append(f"type: {attrs['connType']}")
+    if attrs.get('adjType'):
+        parts.append(f"adj: {attrs['adjType']}")
+    if attrs.get('directed'):
+        parts.append(f"directed: {attrs['directed']}")
+    if attrs.get('targetName'):
+        parts.append(f"target: {attrs['targetName']}")
+    if attrs.get('sourceName'):
+        parts.append(f"source: {attrs['sourceName']}")
+    return f"{name} ({', '.join(parts)})" if parts else name
+
+
+def _record_binding(item, cls, dn_to_graph, graph_name_to_dn, graph_bindings):
+    attrs = simple_attr(item, cls)
+    dn = attrs.get('dn', '')
+    contract = None
+    subject = None
+    for part in dn.split('/'):
+        if part.startswith('brc-'):
+            contract = part[4:]
+        elif part.startswith('subj-'):
+            subject = part[5:]
+    graph_dn = attrs.get('tDn')
+    if not graph_dn:
+        graph_name = attrs.get('tnVnsAbsGraphName') or attrs.get('graphName')
+        if graph_name:
+            graph_dn = graph_name_to_dn.get(graph_name)
+    if graph_dn and graph_dn not in dn_to_graph:
+        # Sometimes tDn references the graph's AbsGraph child directly
+        for candidate in dn_to_graph:
+            if graph_dn.startswith(candidate):
+                graph_dn = candidate
+                break
+    if not graph_dn or graph_dn not in dn_to_graph:
+        return
+    contract_name = contract or attrs.get('tnVzBrCPName')
+    if not contract_name:
+        return
+    subject_name = subject or attrs.get('tnVzSubjName')
+    binding = {
+        'contract': contract_name,
+        'subject': subject_name or '—',
+    }
+    existing = graph_bindings[graph_dn]
+    if binding not in existing:
+        existing.append(binding)

--- a/templates/tenant.md.j2
+++ b/templates/tenant.md.j2
@@ -124,9 +124,19 @@ _No L2Outs._
 
 ## Service Graphs
 {% if tenant.service_graphs %}
-| Graph | Nodes | Redirect Policies | Bound Contract→Subject |
-|-------|-------|-------------------|------------------------|
-{% for g in tenant.service_graphs %}| {{ g.name }} | {{ g.nodes|map(attribute='name')|list|join(' → ') }} | {{ g.redirect_policies|join(', ') }} | {{ g.bound_contract_subjects|map(attribute='contract')|list|join(', ') }} |
+| Graph | Nodes (Function Type & Connectors) | Connector Flows | Redirect Policies | Bound Contract → Subject |
+|-------|------------------------------------|-----------------|-------------------|--------------------------|
+{% for g in tenant.service_graphs %}| {{ g.name }} |{%- if g.nodes and g.nodes|length > 0 -%}
+  {%- for n in g.nodes -%}
+    {{ n.name }}{% if n.funcType %} ({{ n.funcType }}){% endif %}
+    {%- if n.connectors and n.connectors|length > 0 %}<br/><small>Connectors: {%- for c in n.connectors -%}{{ c.summary }}{% if not loop.last %}, {% endif %}{%- endfor -%}</small>{% endif %}
+    {% if not loop.last %}<br/><br/>{% endif %}
+  {%- endfor -%}
+{%- else -%} —{%- endif -%} | {%- if g.connections and g.connections|length > 0 -%}{%- for c in g.connections -%}{{ c.summary }}{% if not loop.last %}<br/>{% endif %}{%- endfor -%}{%- else -%}—{%- endif -%} | {{ g.redirect_policies|join(', ') if g.redirect_policies else '—' }} |{%- if g.bound_contract_subjects and g.bound_contract_subjects|length > 0 -%}
+  {%- for b in g.bound_contract_subjects -%}
+    {{ b.contract }}{% if b.subject and b.subject != '—' %} → {{ b.subject }}{% endif %}{% if not loop.last %}<br/>{% endif %}
+  {%- endfor -%}
+{%- else -%}—{%- endif -%} |
 {% endfor %}
 {% else %}
 _No Service Graphs._

--- a/templates/testing.md.j2
+++ b/templates/testing.md.j2
@@ -47,8 +47,10 @@ _No L3Outs to test._
 ### 5) Service Graphs
 {% for g in t.service_graphs or [] %}
 - **Graph {{ g.name }}** — Validate traffic redirection across nodes:
-  - Nodes: {% for n in g.nodes %}{{ n.name }} ({{ n.funcType|default('func') }}){% if not loop.last %}, {% endif %}{% endfor %}
-  - If redirect policies: {{ g.redirect_policies|map(attribute='name')|list|join(', ') or 'None' }}
+  - Nodes: {% for n in g.nodes %}{{ n.name }}{% if n.funcType %} ({{ n.funcType }}){% endif %}{% if n.connectors %} — connectors: {% for c in n.connectors %}{{ c.summary }}{% if not loop.last %}, {% endif %}{% endfor %}{% endif %}{% if not loop.last %}; {% endif %}{% endfor %}
+  - Connector flows: {% if g.connections %}{% for c in g.connections %}{{ c.summary }}{% if not loop.last %}; {% endif %}{% endfor %}{% else %}None{% endif %}
+  - Redirect policies: {{ g.redirect_policies|join(', ') if g.redirect_policies else 'None' }}
+  - Bound contract subjects: {% if g.bound_contract_subjects %}{% for b in g.bound_contract_subjects %}{{ b.contract }}{% if b.subject and b.subject != '—' %}→{{ b.subject }}{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}{% else %}None{% endif %}
   - Run bidirectional tests (client↔server) and ensure policy hits/logs on device.
 {% endfor %}
 

--- a/templates/tests.md.j2
+++ b/templates/tests.md.j2
@@ -32,9 +32,11 @@ This file is generated from discovered features. Fill actual results as you exec
 {% if t.service_graphs %}
 ### Service Graph Tests
 {% for g in t.service_graphs %}
-- [ ] **Graph {{ g.name }}** nodes: {{ g.nodes|map(attribute='name')|list|join(' → ') }}
+- [ ] **Graph {{ g.name }}** nodes:
+  - {%- for n in g.nodes %} {{ n.name }}{% if n.funcType %} ({{ n.funcType }}){% endif %}{% if not loop.last %};{% endif %}{% endfor %}
+- [ ] Connector flows: {% if g.connections %}{% for c in g.connections %}{{ c.summary }}{% if not loop.last %}, {% endif %}{% endfor %}{% else %}None{% endif %}
   - [ ] Verify redirect policy hits on device (counters/logs)
-  - [ ] Exercise Contract Subjects bound to this graph ({{ g.bound_contract_subjects|map(attribute='contract')|list|join(', ') }})
+  - [ ] Exercise Contract Subjects bound to this graph ({% if g.bound_contract_subjects %}{% for b in g.bound_contract_subjects %}{{ b.contract }}{% if b.subject and b.subject != '—' %}→{{ b.subject }}{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}{% else %}None{% endif %})
   - [ ] Verify return traffic symmetry and health probes
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
## Summary
- harvest detailed service graph information including nodes, connectors, connections, and contract bindings
- surface connector flows, redirect policies, and bound contract subjects in the tenant markdown output
- expand service-graph guidance in test templates to cover connector and contract validation

## Testing
- python -m compileall aci_docgen templates

------
https://chatgpt.com/codex/tasks/task_e_68df9d34273c8323a731ad15a337f2a0